### PR TITLE
Add poc-yaml-apache-nifi-api-unauthorized-access

### DIFF
--- a/pocs/apache-nifi-api-unauthorized-access.yml
+++ b/pocs/apache-nifi-api-unauthorized-access.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-apache-nifi-api-unauthorized-access
+manual: true
+transport: http
+rules:
+    r0:
+        request:
+            cache: true
+            method: GET
+            path: /nifi-api/flow/current-user
+            follow_redirects: false
+        expression: response.status == 200 && response.content_type.contains("json") && response.body.bcontains(b"\"identity\":\"anonymous\",\"anonymous\":true")
+expression: r0()
+detail:
+    author: wulalalaaa(https://github.com/wulalalaaa)
+    links:
+        - https://nifi.apache.org/docs/nifi-docs/rest-api/index.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Apache nifi rest api 未授权访问漏洞
## 测试环境
FOFA DORK:title=="NiFi"
## 备注
![image](https://user-images.githubusercontent.com/93594084/140005832-cf9aa5df-028a-4184-baea-3c67d2ee464f.png)
![image](https://user-images.githubusercontent.com/93594084/140005844-fafe758a-f571-480d-bac1-cd264d27808f.png)
